### PR TITLE
ci: expand clang-tidy to bugprone-*, misc-*, modernize-*, performance-*, readability-*

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,20 +2,18 @@
 Checks: >
   clang-diagnostic-*,
   clang-analyzer-*,
-  modernize-use-nullptr,
-  modernize-use-override,
-  modernize-use-auto,
-  modernize-use-using,
-  modernize-avoid-c-arrays,
-  modernize-use-default-member-init,
-  modernize-use-emplace,
-  modernize-redundant-void-arg,
+  bugprone-*,
+  misc-*,
+  performance-*,
+  modernize-*,
+  readability-*,
   cppcoreguidelines-avoid-goto,
   cppcoreguidelines-init-variables,
-  performance-unnecessary-copy-initialization,
-  performance-move-const-arg,
-  readability-braces-around-statements,
-  readability-qualified-auto,
-  -modernize-use-trailing-return-type
-WarningsAsErrors: ""
-HeaderFilterRegex: "include/.*"
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -readability-magic-numbers,
+  -misc-include-cleaner
+
+WarningsAsErrors: "clang-diagnostic-*,clang-analyzer-*,bugprone-*"
+HeaderFilterRegex: "(include|src)/.*"
+AnalyzeTemporaryDtors: true


### PR DESCRIPTION
## Summary

- Replaces the hand-curated list of modernize/performance/readability checks with full wildcards
- Adds `bugprone-*` and `misc-*` to catch common C++ pitfalls
- Excludes `-readability-magic-numbers`, `-modernize-use-nodiscard`, `-modernize-use-trailing-return-type`, and `-misc-include-cleaner` (noisy without a full `compile_commands.json`)
- Promotes `clang-diagnostic-*`, `clang-analyzer-*`, and `bugprone-*` to `WarningsAsErrors`
- Broadens `HeaderFilterRegex` to cover both `include/` and `src/`
- Enables `AnalyzeTemporaryDtors` for more accurate lifetime analysis

## Test plan

- [ ] Lint CI passes (clang-tidy clean on `src/weather_clock.cc`)
- [ ] If any new checks fire, evaluate and either fix or add targeted exclusions