### PR TITLE
ci: replace unpinned curl actionlint install with pinned action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,10 +20,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install and run actionlint
-        run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint
+      - name: Install actionlint
+        uses: jaxxstorm/action-install-gh-release@c5ead9a448b4660cf1e7866ee22e4dc56538031a # ratchet:jaxxstorm/action-install-gh-release@v2
+        with:
+          repo: rhysd/actionlint
+          tag: v1.7.12
+
+      - name: Run actionlint
+        run: actionlint
 
   zizmor:
     name: Zizmor - Security Analysis


### PR DESCRIPTION
## Problem

The `Actionlint` CI job was installing actionlint via:

```bash
bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
```

This is fragile in two ways:
- Completely unpinned — fetches whatever version is current at run time
- No error handling — if the GitHub releases download returns a bad response, `tar` fails with `Error is not recoverable` and the job exits 2 (as seen in run #27123322948)

## Fix

Replaces the curl install with `jaxxstorm/action-install-gh-release`, the same pattern already used for ratchet and zizmor in this workflow, pinned to actionlint v1.7.12.