### PR TITLE
fix: heat index/humidity overlap and marquee scroll rate

### DIFF
--- a/src/weather_clock.cc
+++ b/src/weather_clock.cc
@@ -44,6 +44,7 @@ struct AppConfig
     std::string font_path = "fonts/5x7.bdf";
     std::string log_level = "INFO";
     std::string ntp_server = "pool.ntp.org";  // handled by systemd-timesyncd
+    int scroll_ms_per_pixel = 80;
     bool mqtt_enabled = false;
     std::string mqtt_broker = "localhost";
     int mqtt_port = 1883;
@@ -166,6 +167,8 @@ bool LoadConfig(const std::string& path, AppConfig& cfg)
                 cfg.font_path = val;
             else if (key == "LOG_LEVEL")
                 cfg.log_level = val;
+            else if (key == "SCROLL_MS_PER_PIXEL")
+                cfg.scroll_ms_per_pixel = SafeInt(val, 80);
         }
         else if (section == "NTP")
         {
@@ -677,6 +680,7 @@ int main(int argc, char** argv)
     bool show_main_weather = true;
     time_t last_switch = time(nullptr);
     int scroll_x = offscreen->width();
+    auto last_scroll_tp = std::chrono::steady_clock::now();
 
     auto start_tp = std::chrono::steady_clock::now();
     auto to_seconds = [](auto tp)
@@ -780,12 +784,18 @@ int main(int argc, char** argv)
         {
             rgb_matrix::DrawText(offscreen, font, scroll_x, 30, Color(255, 255, 255),
                                  weather_text.c_str());
-            // scroll_x + est: est > 0 guaranteed by the empty check above, so no
-            // signed overflow — scroll_x resets before it can reach INT_MIN
-            if (scroll_x + est < 0)
-                scroll_x = offscreen->width();
-            else
-                --scroll_x;
+            auto now_scroll = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  now_scroll - last_scroll_tp)
+                                  .count();
+            if (elapsed_ms >= cfg.scroll_ms_per_pixel)
+            {
+                if (scroll_x + est < 0)
+                    scroll_x = offscreen->width();
+                else
+                    --scroll_x;
+                last_scroll_tp = now_scroll;
+            }
         }
         else
         {
@@ -803,6 +813,7 @@ int main(int argc, char** argv)
             show_main_weather = !show_main_weather;
             last_switch = time(nullptr);
             scroll_x = offscreen->width();
+            last_scroll_tp = std::chrono::steady_clock::now();
         }
     }
 

--- a/src/weather_clock.cc
+++ b/src/weather_clock.cc
@@ -446,6 +446,14 @@ static Color TempColor(int tempCelsius)
     return Color(static_cast<int>(r * 255), static_cast<int>(g * 255), static_cast<int>(b * 255));
 }
 
+static int TextWidth(const rgb_matrix::Font& font, const std::string& text)
+{
+    int width = 0;
+    for (unsigned char ch : text)
+        width += font.CharacterWidth(ch);
+    return width;
+}
+
 static Color HumidityColor(int humidity)
 {
     if (humidity < 30)
@@ -692,6 +700,7 @@ int main(int argc, char** argv)
     int cached_minute = -1;
     int last_tF = -9999, last_fF = -9999, last_hum = -9999;
     std::string temp_str, feels_str, humid_str;
+    int feels_width = 0;
     Color temp_color{255, 255, 255}, humid_color{255, 255, 255};
     uint32_t last_weather_version = UINT32_MAX;
     std::string mainw, desc;
@@ -770,13 +779,19 @@ int main(int argc, char** argv)
             humid_str = std::to_string(hum) + "%";
             temp_color = TempColor(tC);
             humid_color = HumidityColor(hum);
+            feels_width = TextWidth(font, feels_str);
         }
+
+        // Heat index right-aligns against the humidity column so a 3-digit
+        // reading slides left instead of overlapping "51%".
+        constexpr int kHumidX = 49;
+        int feels_x = std::min(33, kHumidX - feels_width - 1);
 
         rgb_matrix::DrawText(offscreen, font, 2, 10, dynamic, daybuf);
         rgb_matrix::DrawText(offscreen, font, 34, 10, dynamic, timebuf);
         rgb_matrix::DrawText(offscreen, font, 2, 20, temp_color, temp_str.c_str());
-        rgb_matrix::DrawText(offscreen, font, 33, 20, temp_color, feels_str.c_str());
-        rgb_matrix::DrawText(offscreen, font, 49, 20, humid_color, humid_str.c_str());
+        rgb_matrix::DrawText(offscreen, font, feels_x, 20, temp_color, feels_str.c_str());
+        rgb_matrix::DrawText(offscreen, font, kHumidX, 20, humid_color, humid_str.c_str());
 
         const std::string& weather_text = show_main_weather ? mainw : desc;
         int est = static_cast<int>(weather_text.size()) * 6;

--- a/src/weather_clock.cc
+++ b/src/weather_clock.cc
@@ -449,8 +449,7 @@ static Color TempColor(int tempCelsius)
 static int TextWidth(const rgb_matrix::Font& font, const std::string& text)
 {
     int width = 0;
-    for (unsigned char ch : text)
-        width += font.CharacterWidth(ch);
+    for (unsigned char ch : text) width += font.CharacterWidth(ch);
     return width;
 }
 
@@ -800,9 +799,9 @@ int main(int argc, char** argv)
             rgb_matrix::DrawText(offscreen, font, scroll_x, 30, Color(255, 255, 255),
                                  weather_text.c_str());
             auto now_scroll = std::chrono::steady_clock::now();
-            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                  now_scroll - last_scroll_tp)
-                                  .count();
+            auto elapsed_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(now_scroll - last_scroll_tp)
+                    .count();
             if (elapsed_ms >= cfg.scroll_ms_per_pixel)
             {
                 if (scroll_x + est < 0)


### PR DESCRIPTION
## Summary
- Heat index text was drawn at a fixed x position, so a 3-digit reading (e.g. 102) overlapped the humidity percentage. It now right-aligns against the humidity column using the actual rendered text width.
- The marquee weather-text scroll had become tied to frame rate after a previous perf change removed the VSync sleep; it's now throttled by elapsed wall time (`SCROLL_MS_PER_PIXEL`, default 80ms).

## Test plan
- [x] Cross-built and ran on the physical Pi Zero W display; verified with a live 102°F heat index / 51% humidity reading that both values are now fully visible
- [x] Verified layout math against the actual `fonts/5x7.bdf` glyph widths across the realistic heat-index range