### PR TITLE
fix: reject out-of-range MQTT sensor readings

### DIFF
--- a/src/weather_clock.cc
+++ b/src/weather_clock.cc
@@ -323,6 +323,12 @@ void MqttWeatherThread(const AppConfig& cfg, WeatherState& state, Logger& logger
                 c->logger->Warning("MQTT message missing tempF or humidity: " + payload);
                 return;
             }
+            if (*temp_f < -60.0 || *temp_f > 150.0 || *hum < 0.0 || *hum > 100.0)
+            {
+                c->logger->Warning("MQTT message has out-of-range sensor values, ignoring: " +
+                                   payload);
+                return;
+            }
 
             double tf = *temp_f;
             double tc = (tf - 32.0) * 5.0 / 9.0;


### PR DESCRIPTION
## Summary
- The MQTT sensor feed briefly published `INT32_MAX` (2147483647) for both `tempF` and `humidity`, which rendered as an unreadable smear across the display since nothing validated values off the wire.
- Reject readings outside a plausible range (-60 to 150F, 0 to 100% humidity) and keep the last good state instead of displaying garbage.

Not releasing yet — holding this for a future release with more than one fix/feature bundled.

## Test plan
- [x] Deployed to the physical Pi and confirmed the service builds/runs cleanly with the change
- [ ] Confirm the reject path logs correctly next time the sensor glitches (couldn't force-trigger; the upstream sensor self-recovered before this was live)