### PR TITLE
fix: OWM feels_like overwrites MQTT-owned temperature

### DIFF
--- a/src/weather_clock.cc
+++ b/src/weather_clock.cc
@@ -239,8 +239,12 @@ void WeatherThread(const AppConfig& cfg, WeatherState& state, Logger& logger)
                         f = static_cast<int>(std::lround((f * 9.0 / 5.0) + 32));
                     }
                     // If MQTT data was received within the last 15 minutes, let it own
-                    // temperature and humidity — OWM still provides the fields the
-                    // sensor cannot (feels_like, sunrise/sunset, description).
+                    // temperature/humidity/feels_like — OWM still provides the fields the
+                    // sensor cannot (sunrise/sunset, description). feels_like must stay
+                    // gated with temperature: it is a regression computed from OWM's own
+                    // temp/humidity, so pairing it with the MQTT temp produces a
+                    // self-inconsistent reading (e.g. 73F display temp with a feels_like
+                    // computed off an 86F OWM reading).
                     bool mqtt_fresh = state.mqtt_last_received.load() != 0 &&
                                       (time(nullptr) - state.mqtt_last_received.load()) < 900;
                     std::lock_guard<std::mutex> lk(state.mu);
@@ -249,9 +253,9 @@ void WeatherThread(const AppConfig& cfg, WeatherState& state, Logger& logger)
                         state.temperature = t;
                         state.temperature_c = t_c;
                         state.humidity = static_cast<int>(std::lround(*hum));
+                        state.feels_like = f;
+                        state.feels_like_c = f_c;
                     }
-                    state.feels_like = f;
-                    state.feels_like_c = f_c;
                     state.sunrise = static_cast<long>(*sr);
                     state.sunset = static_cast<long>(*ss);
                     state.main_weather = *mainw;


### PR DESCRIPTION
## Summary
- `WeatherThread`'s OWM poll gated `temperature`/`humidity` behind `mqtt_fresh` but wrote `feels_like`/`feels_like_c` unconditionally, every 10-minute poll.
- Result: when MQTT sensor data owns the displayed temperature, the feels_like field still gets overwritten with a value computed from OWM's own (different) temperature/humidity — e.g. a 73°F display temp paired with a feels_like of 90°F computed off an ~86°F OWM reading. Physically inconsistent (Rothfusz heat index is only valid ≥80°F and meaningless when paired with a mismatched temp).
- Fix: move the `feels_like`/`feels_like_c` assignment inside the existing `if (!mqtt_fresh)` block so it's gated the same way as temperature/humidity.

Not merging yet — holding for the upcoming release per request.

## Test plan
- [x] Builds clean on device (`make`), no new warnings
- [ ] Confirm on next merge/release that feels_like tracks the MQTT-owned temp when sensor data is fresh, and OWM's feels_like only applies when MQTT is stale