### PR TITLE
chore: enable Dependabot (pip) and pin requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot: automated dependency and security updates
+# https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Pillow
-requests
-ntplib
-paho-mqtt
-pytest
+Pillow>=12.3.0
+requests>=2.34.2
+ntplib>=0.4.0
+paho-mqtt>=2.1.0
+pytest>=9.1.1


### PR DESCRIPTION
## Summary
- requirements.txt had no version pins at all, so there was no baseline for Dependabot (or anyone) to know what's actually installed on-device or whether it's carrying a known CVE
- Floor-pins deps to current stable versions and adds .github/dependabot.yml (pip, weekly), matching the setup just added to jkeychan.github.io

## Test plan
- [ ] Confirm `pip install -r requirements.txt` still resolves cleanly on target hardware